### PR TITLE
125: changed button colors to the main campaign color

### DIFF
--- a/src/scss/blocks/_p4-action-covers.scss
+++ b/src/scss/blocks/_p4-action-covers.scss
@@ -77,17 +77,17 @@
 		&.cover-card {
 			&:hover {
 				.btn {
-					background-color: #{nth($colors_3, $i)};
+					background-color: #{nth($colors_1, $i)};
 				}
 			}
 
 			a.btn-action {
-				background-color: #{nth($colors_3, $i)};
-				color: #{nth($colors_3_font, $i)};
+				background-color: #{nth($colors_1, $i)};
+				color: #{nth($colors_1_font, $i)};
 
 				&:hover {
-					background-color: #{nth($colors_1, $i)};
-					color: #{nth($colors_1_font, $i)};
+					background-color: #{nth($colors_3, $i)};
+					color: #{nth($colors_3_font, $i)};
 				}
 			}
 		}


### PR DESCRIPTION
The colors were the same like buttons on explore pages before, but it makes more sense to use the primary color for recognition when the element is used on other pages.