### PR TITLE
300: Bugfix for donation overlay

### DIFF
--- a/src/scss/layout/_layout.scss
+++ b/src/scss/layout/_layout.scss
@@ -40,6 +40,10 @@ body .top-navigation {
 	display: none;
 }
 
+/* Bugfix for donation overlay issue: https://tickets.greenpeace.ch/view.php?id=300 */
+div.page-template > * {
+	z-index: auto;
+}
 
 @include media('<=desktop') {
 	.post-content .container {


### PR DESCRIPTION
Greedy selector sets a z-index value in master theme that prevents the RaiseNow Lema credit card overlay being displayed properly.