### PR TITLE
295: Cleanued up tags and post_type menu

### DIFF
--- a/admin/js/editor.js
+++ b/admin/js/editor.js
@@ -104,15 +104,20 @@ wp.domReady(() => {
 	// core/table
 	wp.blocks.unregisterBlockStyle('core/table', 'stripes');
 	
+	
 	/*
-	* Prevent two tag menus to show on the same post edit page.
-	* Planet4 adds its own element for everyone except admins. So we remove the default UI for
-	* - Everyone except admins Admins
-	* - Only on posts where Planet4 adds its UI (not our custom post types that use tags)
+	* Remove the default tags menu where needed.
 	*
-	*  @see: https://github.com/greenpeace/planet4-master-theme/blob/f02ceaf22a0fc455180395c4414efc19e6f36933/classes/class-p4-master-site.php#L742-L750
+	* Planet4 replaces the default sidebar element in the post edit screen (for
+	* everyone except admins) with a custom element that doesn't allow creating
+	* new tags.
+	* We've added the same menu to our custom post types, so we need to hide the
+	* default element as well.
+	*
+	* @see: https://github.com/greenpeace/planet4-master-theme/blob/f02ceaf22a0fc455180395c4414efc19e6f36933/classes/class-p4-master-site.php#L742-L750
+	* @see: https://github.com/greenpeace/planet4-child-theme-switzerland/blob/8900f2faaf924fde32482be06c0c96b238ce2095/includes/gutenberg-sidebar.php#L75-L91
 	*/
-	if (gpchUserData.roles.indexOf("administrator") == -1 && gpchUserData.post_type != "gpch_event" && gpchUserData.post_Type != "gpch_magredirect") { // Current user is NOT admin
+	if (gpchUserData.post_type === "gpch_event" || gpchUserData.post_type === "gpch_magredirect" || gpchUserData.post_type === "gpch_archived_post") { // all users, ceratin post types
 		wp.data.dispatch( 'core/edit-post').removeEditorPanel( 'taxonomy-panel-post_tag' );
 	}
 });

--- a/includes/gutenberg-sidebar.php
+++ b/includes/gutenberg-sidebar.php
@@ -15,52 +15,20 @@ add_action( 'init', 'p4_child_theme_gpch_post_editing' );
 
 
 /**
- * add the custom taxonomy "Page Type" of Planet4 to the sidebar
+ * Adds the Planet4 restricted tag box to our own custom post types
  */
-if ( function_exists( 'acf_add_local_field_group' ) ) {
-	acf_add_local_field_group( array(
-		'key'                   => 'group_5cd97c24f05ab',
-		'title'                 => __( 'Page Type', 'planet4-child-theme-switzerland' ),
-		'fields'                => array(
-			array(
-				'key'               => 'field_5cd97c2e6667c',
-				'label'             => '',
-				'name'              => 'p4-page-type',
-				'type'              => 'taxonomy',
-				'instructions'      => '',
-				'required'          => 0,
-				'conditional_logic' => 0,
-				'wrapper'           => array(
-					'width' => '',
-					'class' => '',
-					'id'    => '',
-				),
-				'taxonomy'          => 'p4-page-type',
-				'field_type'        => 'select',
-				'allow_null'        => 0,
-				'add_term'          => 0,
-				'save_terms'        => 1,
-				'load_terms'        => 1,
-				'return_format'     => 'id',
-				'multiple'          => 0,
-			),
-		),
-		'location'              => array(
-			array(
-				array(
-					'param'    => 'post_type',
-					'operator' => '==',
-					'value'    => 'post',
-				),
-			),
-		),
-		'menu_order'            => - 100,
-		'position'              => 'side',
-		'style'                 => 'default',
-		'label_placement'       => 'top',
-		'instruction_placement' => 'label',
-		'hide_on_screen'        => '',
-		'active'                => true,
-		'description'           => '',
-	) );
+function gpch_add_restricted_tags_box() {
+	// Get the class that contains the function to print the custom menu
+	$context = Timber::get_context();
+	$site    = $context['site'];
+
+	add_meta_box(
+		'restricted_tags_box',
+		__( 'Tags', 'planet4-master-theme-backend' ),
+		[ $site, 'print_restricted_tags_box' ],
+		[ 'gpch_event', 'gpch_magredirect', 'gpch_archived_post' ],
+		'side'
+	);
 }
+
+add_action( 'admin_menu', 'gpch_add_restricted_tags_box' );


### PR DESCRIPTION
The post type menu is now done through the master theme, we can remove it from the child. Same thing for the custom meta box to edit tags, but we still need to add that to our custom post types.