### PR TITLE
319: remove top margin from headers inside blocks

### DIFF
--- a/src/scss/blocks/_core-heading.scss
+++ b/src/scss/blocks/_core-heading.scss
@@ -10,6 +10,16 @@ h2.page-section-header {
 	color: $color_standard_1;
 }
 
+/* Remove top margin inside certain blocks that already have a margin */
+.block.article-listing,
+.block.covers-block {
+	h2,
+	h2.page-section-header {
+		margin-top: 0;
+	}
+}
+
+
 h3 {
 	margin-top: 2em;
 	font-size: 1.5rem;


### PR DESCRIPTION
Some blocks (article list, covers) already have a top margin, so titles inside don't need to add more spacing.