### PR TITLE
Allow reusable blocks

### DIFF
--- a/includes/gutenberg-blocks.php
+++ b/includes/gutenberg-blocks.php
@@ -13,6 +13,7 @@ if ( ! function_exists( 'p4_child_theme_gpch_whitelist_blocks' ) ) {
 	 */
 	function p4_child_theme_gpch_whitelist_blocks( $allowed_blocks, $post ) {
 		$allowed_blocks_general = array(
+			'core/block', // needed for reusable blocks to work
 			'core/paragraph',
 			'core/heading',
 			'core/image',


### PR DESCRIPTION
Reusable block menu option is not shown unless "core/block" type is
allowed. See https://jira.greenpeace.org/browse/PLANET-4346#comment-196224