### PR TITLE
385: Removed take action boxout code from events

### DIFF
--- a/includes/post-templates/gpch-event-single.php
+++ b/includes/post-templates/gpch-event-single.php
@@ -42,13 +42,6 @@ $context['og_description']      = $post->get_og_description();
 $context['og_image_data']       = $post->get_og_image();
 $context['custom_body_classes'] = 'white-bg';
 
-// Build the shortcode for take action boxout block
-// Break the content to retrieve first 2 paragraphs and split the content if the take action page has been defined.
-if ( ! empty( $take_action_page ) ) {
-	$post->take_action_page   = $take_action_page;
-	$post->take_action_boxout = "[shortcake_take_action_boxout take_action_page='$take_action_page' /]";
-}
-
 $context['post_tags'] = implode( ', ', $post->tags() );
 
 if ( post_password_required( $post->ID ) ) {

--- a/templates/single-gpch_event.twig
+++ b/templates/single-gpch_event.twig
@@ -47,21 +47,6 @@
 				{% endif %}
 			</div>
 		</header>
-
-		<!-- Post Block Start -->
-		<div class="container">
-			<div class="post-content">
-				{% if ( post.take_action_boxout ) %}
-					{{ post.take_action_boxout|shortcodes|raw }}
-				{% endif %}
-				<div class="post-content-lead">
-					<article class="post-details clearfix">
-						{{ post.content|raw }}
-					</article>
-				</div>
-			</div>
-		</div>
-		<!-- Post Page Block End -->
 	</article>
 
 {% endblock %}


### PR DESCRIPTION
It's not supported for custom post types because of limitations of the master theme.