### PR TITLE
671: Set sending address for email

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -345,3 +345,16 @@ function gpch_show_drafts_as_parent_pages_elastic( array $status ) {
 }
 
 add_filter( 'ep_indexable_post_status', 'gpch_show_drafts_as_parent_pages_elastic' );
+
+/**
+ * Set the email sending address used for all emails sent through the Planet4 Sendgrid integration
+ * @param $sender_email
+ *
+ * @return string
+ */
+function gpch_change_email_sender ($sender_email) {
+	return 'noreply@greenpeace.ch';
+}
+
+add_filter( 'planet4_sendgrid_sender', 'gpch_change_email_sender' );
+


### PR DESCRIPTION
P4 overrides the sending address for emails sent through Sendgrid. When we start using Planet4's connection to sendgrid with our own account, we need to override the sending address to be from our own domain.