### PR TITLE
672: Disable auto translate in WPML

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -358,3 +358,6 @@ function gpch_change_email_sender ($sender_email) {
 
 add_filter( 'planet4_sendgrid_sender', 'gpch_change_email_sender' );
 
+
+// Disable auto translations in WPML. Might be cause for a bug that changes translated pages back to the original language.
+define( 'WPML_TRANSLATION_AUTO_UPDATE_ENABLED', false );


### PR DESCRIPTION
We suspect auto translate causes a bug that reverts translated pages back to the original language. The bug cannot be replicated, so this is an attempt to fix it without knowing for sure it will work.