### PR TITLE
P4-50: Fix form validation error styles

### DIFF
--- a/src/scss/blocks/_core_heading.scss
+++ b/src/scss/blocks/_core_heading.scss
@@ -33,7 +33,7 @@ div[data-hydrate="planet4-blocks/articles"] {
 }
 
 /* Underline for h2 */
-:not(.submenu-block, .gpch-taskforce-content) > h2:not(.is-style-no-underline):after {
+:not(.submenu-block, .gpch-taskforce-content, .gform_validation_errors) > h2:not(.is-style-no-underline):after {
     content: "";
     display: block;
     position: relative;


### PR DESCRIPTION
H2 underline was showing in error messages when the form is used within a group block.