### PR TITLE
P4-85: Set a scroll margin on top of the page

### DIFF
--- a/src/scss/layout/_page_header.scss
+++ b/src/scss/layout/_page_header.scss
@@ -1,3 +1,8 @@
+/* The height of the menu bar as a scroll offset */
+:target {
+	scroll-margin-top: 80px;
+}
+
 .page-header {
 
     &.page-header-hidden {


### PR DESCRIPTION
Has the effect that anchor links scroll to an offset position leaving space for the overlapping header on top of the page.