### PR TITLE
P4-57: Increase the z-index of the cookie box

### DIFF
--- a/src/scss/layout/_cookies.scss
+++ b/src/scss/layout/_cookies.scss
@@ -1,3 +1,8 @@
+.cookie-notice {
+	/* Make sure the z-index is higher than the floating share buttons of our plugin */
+	z-index: 999999;
+}
+
 .cookies-text {
     font-size: var(--gpch-font-size--standard);
 }


### PR DESCRIPTION
To be higher than the floating share buttons of the social warfare plugin.