### PR TITLE
P4-17: Remove theme support for responsive embeds

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -132,9 +132,6 @@ function gpch_editor_setup() {
 
 	// Enqueue editor styles.
 	add_editor_style( 'admin/css/editor-style.css' );
-
-	// Responsive embeds
-	add_theme_support( 'responsive-embeds' );
 }
 
 add_action( 'after_setup_theme', 'gpch_editor_setup', -9999 );


### PR DESCRIPTION
It's not compatible with the Youtube lite player used in Planet4 and not needed.