### PR TITLE
P4-139: Hide character counter on name fields

### DIFF
--- a/src/scss/blocks/_gravityforms.scss
+++ b/src/scss/blocks/_gravityforms.scss
@@ -16,3 +16,8 @@
 	top: calc(50% - 9px);
 }
 
+/* Hide character counter for name fields */
+input[autocomplete="given-name"] + div.charleft,
+input[autocomplete="family-name"] + div.charleft {
+	display: none;
+}


### PR DESCRIPTION
We added a character limit to the fields, but it's not needed to show a counter for them as most people will never add a name that's longer.