### PR TITLE
ES-760: Improve h1 styling

### DIFF
--- a/src/scss/blocks/_core_heading.scss
+++ b/src/scss/blocks/_core_heading.scss
@@ -45,3 +45,24 @@ div[data-hydrate="planet4-blocks/articles"] {
 	display: none !important;
 }
 
+
+/*@include media("<=tablet") {*/
+@media (max-width: 1199px) {
+	.page-header-title {
+		max-width: 100%;
+	}
+}
+
+/* Master theme corrections */
+@media (min-width: 768px) {
+	.page-header .container > :not(.row) {
+		max-width: 100%;
+	}
+}
+
+@media (min-width: 992px) {
+	.page-header .container > :not(.row) {
+		max-width: 100%;
+	}
+}
+


### PR DESCRIPTION
Improve h1 style in .page-header-title elements to use the full width of smaller screens.